### PR TITLE
docs: update quick-start.md

### DIFF
--- a/sites/docs/content/quick-start.md
+++ b/sites/docs/content/quick-start.md
@@ -60,7 +60,7 @@ In Superforms fashion, we'll return the form from a load function to seamlessly 
 ```ts title="src/routes/settings/+page.server.ts"
 import type { PageServerLoad } from "./$types";
 import { schema } from "./schema";
-import { superValidate } from "sveltekit-superforms/server";
+import { superValidate } from "sveltekit-superforms";
 import { zod } from "sveltekit-superforms/adapters";
 
 export const load: PageServerLoad = async () => {


### PR DESCRIPTION
To be consistent with Superforms docs suggest we drop /server and import from top level instead given v2