### PR TITLE
fix: typos contraints to constraints

### DIFF
--- a/packages/formsnap/src/lib/components/types.ts
+++ b/packages/formsnap/src/lib/components/types.ts
@@ -217,7 +217,7 @@ export type FieldSlotProps<T extends Record<string, unknown>, U extends FormPath
 	errors: string[];
 
 	/**
-	 * The contraints for the field.
+	 * The constraints for the field.
 	 *
 	 * @see {@link https://superforms.rocks/concepts/client-validation#constraints Constraints Documentation}
 	 */
@@ -244,7 +244,7 @@ export type FieldsetSlotProps<T extends Record<string, unknown>, U extends FormP
 	errors: string[];
 
 	/**
-	 * The contraints for the field.
+	 * The constraints for the field.
 	 *
 	 * @see {@link https://superforms.rocks/concepts/client-validation#constraints Constraints Documentation}
 	 */

--- a/sites/docs/content/components/element-field.md
+++ b/sites/docs/content/components/element-field.md
@@ -133,7 +133,7 @@ To maintain the type safety of the component, we'll need to use some generics, w
 </script>
 
 <!-- passing the slot props down are optional -->
-<ElementField {form} {name} let:value let:errors let:tainted let:contraints>
+<ElementField {form} {name} let:value let:errors let:tainted let:constraints>
 	<slot {value} {errors} {tainted} {constraints} />
 	<FieldErrors />
 </ElementField>

--- a/sites/docs/content/components/field.md
+++ b/sites/docs/content/components/field.md
@@ -79,7 +79,7 @@ To maintain the type safety of the component, we'll need to use some generics, w
 </script>
 
 <!-- passing the slot props down are optional -->
-<Field {form} {name} let:value let:errors let:tainted let:contraints>
+<Field {form} {name} let:value let:errors let:tainted let:constraints>
 	<slot {value} {errors} {tainted} {constraints} />
 	<FieldErrors />
 </Field>


### PR DESCRIPTION
Hello

I was copy pasting the example here https://www.formsnap.dev/docs/components/field and saw a type error.
When i changed "contraints" to "constraints" it worked for me.

I saw that this typo was in multiple places and changed it there too.