### PR TITLE
chore: support Svelte 5 peer dep

### DIFF
--- a/.changeset/small-zoos-check.md
+++ b/.changeset/small-zoos-check.md
@@ -1,0 +1,5 @@
+---
+"formsnap": patch
+---
+
+chore: support Svelte 5 as a peer dependency

--- a/packages/formsnap/package.json
+++ b/packages/formsnap/package.json
@@ -36,7 +36,7 @@
 		"!dist/**/*.spec.*"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0",
+		"svelte": "^4.0.0 || ^5.0.0-next.1",
 		"sveltekit-superforms": "^2.3.0"
 	},
 	"devDependencies": {

--- a/packages/formsnap/package.json
+++ b/packages/formsnap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "formsnap",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"scripts": {
 		"dev": "pnpm watch",
 		"build": "pnpm run package",

--- a/packages/formsnap/package.json
+++ b/packages/formsnap/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "formsnap",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"scripts": {
 		"dev": "pnpm watch",
 		"build": "pnpm run package",


### PR DESCRIPTION
Resolves npm 7+ peer dependency errors