### PR TITLE
docs: fix quick start missing import in docs field

### DIFF
--- a/.changeset/loud-students-mate.md
+++ b/.changeset/loud-students-mate.md
@@ -1,0 +1,5 @@
+---
+"docs": minor
+---
+
+Update include in code sample

--- a/sites/docs/content/quick-start.md
+++ b/sites/docs/content/quick-start.md
@@ -108,6 +108,7 @@ We'll start with the `email` field and work our way down.
 ```svelte title="src/routes/settings/+page.svelte"
 <script lang="ts">
 	import { superForm } from "sveltekit-superforms";
+	import { Field } from "formsnap";
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import type { PageData } from "./$types.js";
 	import { allergies, schema, themes } from "./schema.js";


### PR DESCRIPTION
Just noticed this was missing. 